### PR TITLE
Remove self hosted workflows

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build-and-deploy:
     if: github.event.base_ref == 'refs/heads/main'
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Related Issue

Closes #18 

## Overall description of your work

I've changed all self-hosted workflows to GitHub hosted because self-hosted runners are not sported on public repositories.

## Technical decisions you've made

*Nothing*

## Task list

- [x] Change Build and push workflow

## Additional context [optional]

*Nothing*
